### PR TITLE
Build.PL: update to meta spec version 2

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -8,7 +8,18 @@ my $builder = Module::Build->new(
     dist_author         => 'Aaaaaaa A Aaaaaaa <schwern@pobox.com>',
     dist_abstract       => 'Aaaaaa aaaaa aa aaaaaa Aaaaa aaaa',
 
-    license             => 'perl',
+    license             => 'perl_5',
+
+    meta_merge => {
+        'meta-spec'     => { version => 2 },
+        resources => {
+            repository => {
+                type    => 'git',
+                url     => 'https://github.com/schwern/AAAAAAA.git',
+                web     => 'https://github.com/schwern/AAAAAAA',
+            },
+        },
+    },
 
     configure_requires => { 'Module::Build' => 0.34 },
     build_requires      => {},

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Aaaaaaa A Aaaaaaa <schwern@pobox.com>"
    ],
    "dynamic_config" : 1,
-   "generated_by" : "Module::Build version 0.38, CPAN::Meta::Converter version 2.110930",
+   "generated_by" : "Module::Build version 0.4224",
    "license" : [
       "perl_5"
    ],
@@ -28,9 +28,12 @@
    },
    "release_status" : "stable",
    "resources" : {
-      "license" : [
-         "http://dev.perl.org/licenses/"
-      ]
+      "repository" : {
+         "type" : "git",
+         "url" : "https://github.com/schwern/AAAAAAA.git",
+         "web" : "https://github.com/schwern/AAAAAAA"
+      }
    },
-   "version" : "1.01"
+   "version" : "1.01",
+   "x_serialization_backend" : "JSON::PP version 2.27400_02"
 }

--- a/META.yml
+++ b/META.yml
@@ -4,18 +4,19 @@ author:
   - 'Aaaaaaa A Aaaaaaa <schwern@pobox.com>'
 build_requires: {}
 configure_requires:
-  Module::Build: 0.34
+  Module::Build: '0.34'
 dynamic_config: 1
-generated_by: 'Module::Build version 0.38, CPAN::Meta::Converter version 2.110930'
+generated_by: 'Module::Build version 0.4224, CPAN::Meta::Converter version 2.150010'
 license: perl
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
-  version: 1.4
+  version: '1.4'
 name: AAAAAAAAA
 provides:
   AAAAAAAAA:
     file: aaa/AAAAAAAAA.pm
-    version: 1.01
+    version: '1.01'
 resources:
-  license: http://dev.perl.org/licenses/
-version: 1.01
+  repository: https://github.com/schwern/AAAAAAA.git
+version: '1.01'
+x_serialization_backend: 'CPAN::Meta::YAML version 0.018'


### PR DESCRIPTION
- use `'perl_5'` license string
- add GitHub repository to resources in meta_merge

Q: META.json and META.yml are generated by e.g. `perl Build.PL; ./Build distmeta`. Should these be untracked?